### PR TITLE
Fix spawning multiple esbuilds on same file, that would cause memory usage to spike.

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -297,6 +297,15 @@
       ]
     },
     {
+      "login": "fm-sz",
+      "name": "Florian Mayer",
+      "avatar_url": "https://avatars.githubusercontent.com/u/119663527?v=4",
+      "profile": "https://github.com/fm-sz",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
       "login": "ZachLeviPixel",
       "name": "Zach Levi",
       "avatar_url": "https://avatars.githubusercontent.com/u/131263652?v=4",

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -295,6 +295,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "ZachLeviPixel",
+      "name": "Zach Levi",
+      "avatar_url": "https://avatars.githubusercontent.com/u/131263652?v=4",
+      "profile": "https://github.com/ZachLeviPixel",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -364,6 +364,9 @@ This plugin supports the Serverless [Invoke Local](https://www.serverless.com/fr
       <td align="center" valign="top" width="14.28%"><a href="https://thisisfashion.tv"><img src="https://avatars.githubusercontent.com/u/19397354?v=4?s=70" width="70px;" alt="Sander Kooger"/><br /><sub><b>Sander Kooger</b></sub></a><br /><a href="https://github.com/floydspace/serverless-esbuild/commits?author=sanderkooger" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://caffeinatedcoding.wordpress.com"><img src="https://avatars.githubusercontent.com/u/1588262?v=4?s=70" width="70px;" alt="Adam Swift"/><br /><sub><b>Adam Swift</b></sub></a><br /><a href="https://github.com/floydspace/serverless-esbuild/commits?author=Gleeble" title="Code">💻</a></td>
     </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/ZachLeviPixel"><img src="https://avatars.githubusercontent.com/u/131263652?v=4?s=70" width="70px;" alt="Zach Levi"/><br /><sub><b>Zach Levi</b></sub></a><br /><a href="https://github.com/floydspace/serverless-esbuild/commits?author=ZachLeviPixel" title="Code">💻</a></td>
+    </tr>
   </tbody>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ This plugin supports the Serverless [Invoke Local](https://www.serverless.com/fr
       <td align="center" valign="top" width="14.28%"><a href="http://caffeinatedcoding.wordpress.com"><img src="https://avatars.githubusercontent.com/u/1588262?v=4?s=70" width="70px;" alt="Adam Swift"/><br /><sub><b>Adam Swift</b></sub></a><br /><a href="https://github.com/floydspace/serverless-esbuild/commits?author=Gleeble" title="Code">💻</a></td>
     </tr>
     <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/fm-sz"><img src="https://avatars.githubusercontent.com/u/119663527?v=4?s=70" width="70px;" alt="Florian Mayer"/><br /><sub><b>Florian Mayer</b></sub></a><br /><a href="https://github.com/floydspace/serverless-esbuild/commits?author=fm-sz" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/ZachLeviPixel"><img src="https://avatars.githubusercontent.com/u/131263652?v=4?s=70" width="70px;" alt="Zach Levi"/><br /><sub><b>Zach Levi</b></sub></a><br /><a href="https://github.com/floydspace/serverless-esbuild/commits?author=ZachLeviPixel" title="Code">💻</a></td>
     </tr>
   </tbody>

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ See [example folder](examples) for some example configurations.
 | Esbuild Options        | This plugin can take almost any [Esbuild Javascript Build Option](https://esbuild.github.io/api/#build-api).                                                                                       | [Default Esbuild Options](#default-esbuild-options) |
 | `concurrency`          | The number of concurrent bundle operations to run at once. eg. `8`. _NOTE_: This can be memory intensive and could produce slower builds.                                                          | `Infinity`                                          |
 | `zipConcurrency`       | The number of concurrent zip operations to run at once. eg. `8`. _NOTE_: This can be memory intensive and could produce slower builds.                                                             | `Infinity`                                          |
-| `disableIncremental`   | Disables the use of esbuild `incremental` compilation.                                                                                                                                             | `false`                                             |
 | `exclude`              | An array of dependencies to exclude from the Lambda. This is passed to the esbuild `external` option. Set to `*` to disable packaging `node_modules`                                               | `['aws-sdk']`                                       |
 | `installExtraArgs`     | Optional arguments passed to npm or yarn for `external` dependency resolution. eg. `['--legacy-peer-deps']` for npm v7+ to use legacy `peerDependency` resolution behavior                         | `[]`                                                |
 | `keepOutputDirectory`  | Keeps the `.esbuild` output folder. Useful for debugging.                                                                                                                                          | `false`                                             |
@@ -100,7 +99,6 @@ The following `esbuild` options are automatically set.
 | ------------- | ---------- | ---------------------------------------------------------------------- |
 | `bundle`      | `true`     | Esbuild requires this for use with `external`                          |
 | `entryPoints` | N/A        | Cannot be overridden                                                   |
-| `incremental` | N/A        | Cannot be overridden. Use `disableIncremental` to disable it           |
 | `outDir`      | N/A        | Cannot be overridden                                                   |
 | `platform`    | `'node'`   | Set `format` to `esm` to enable ESM support                            |
 | `target`      | `'node16'` | We dynamically set this. See [Supported Runtimes](#supported-runtimes) |

--- a/examples/complete/package.json
+++ b/examples/complete/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.7.21",
-    "esbuild": "^0.15.9",
+    "esbuild": "^0.19.0",
     "serverless": "^3.22.0",
     "serverless-esbuild": "file:../..",
     "serverless-offline": "^10.2.1",

--- a/examples/config/package.json
+++ b/examples/config/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@types/lodash": "4.14.185",
     "@types/node": "^18.7.21",
-    "esbuild": "^0.15.9",
+    "esbuild": "^0.19.0",
     "serverless": "^3.22.0",
     "serverless-esbuild": "file:../..",
     "serverless-offline": "^10.2.1"

--- a/examples/individually/package.json
+++ b/examples/individually/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@types/lodash": "4.14.185",
     "@types/node": "^18.7.21",
-    "esbuild": "^0.15.9",
+    "esbuild": "^0.19.0",
     "serverless": "^3.22.0",
     "serverless-esbuild": "file:../..",
     "serverless-offline": "^10.2.1"

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.7.21",
-    "esbuild": "^0.15.9",
+    "esbuild": "^0.19.0",
     "serverless": "^3.22.0",
     "serverless-esbuild": "file:../..",
     "serverless-offline": "^10.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,8 +37,8 @@
         "@types/semver": "^7.3.13",
         "@types/serverless": "^3.12.14",
         "all-contributors-cli": "^6.24.0",
-        "esbuild": "^0.16.17",
-        "esbuild-node-externals": "^1.6.0",
+        "esbuild": "^0.19.3",
+        "esbuild-node-externals": "^1.9.0",
         "eslint": "^8.30.0",
         "extract-zip": "^2.0.1",
         "husky": "^8.0.2",
@@ -55,7 +55,7 @@
         "node": ">=14.18.0"
       },
       "peerDependencies": {
-        "esbuild": ">=0.8 <0.18",
+        "esbuild": ">=0.8 <0.20",
         "esbuild-node-externals": "^1.0.0"
       },
       "peerDependenciesMeta": {
@@ -1015,9 +1015,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
-      "integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.3.tgz",
+      "integrity": "sha512-Lemgw4io4VZl9GHJmjiBGzQ7ONXRfRPHcUEerndjwiSkbxzrpq0Uggku5MxxrXdwJ+pTj1qyw4jwTu7hkPsgIA==",
       "cpu": [
         "arm"
       ],
@@ -1031,9 +1031,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
-      "integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.3.tgz",
+      "integrity": "sha512-w+Akc0vv5leog550kjJV9Ru+MXMR2VuMrui3C61mnysim0gkFCPOUTAfzTP0qX+HpN9Syu3YA3p1hf3EPqObRw==",
       "cpu": [
         "arm64"
       ],
@@ -1047,9 +1047,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
-      "integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.3.tgz",
+      "integrity": "sha512-FKQJKkK5MXcBHoNZMDNUAg1+WcZlV/cuXrWCoGF/TvdRiYS4znA0m5Il5idUwfxrE20bG/vU1Cr5e1AD6IEIjQ==",
       "cpu": [
         "x64"
       ],
@@ -1063,9 +1063,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.17.tgz",
-      "integrity": "sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.3.tgz",
+      "integrity": "sha512-kw7e3FXU+VsJSSSl2nMKvACYlwtvZB8RUIeVShIEY6PVnuZ3c9+L9lWB2nWeeKWNNYDdtL19foCQ0ZyUL7nqGw==",
       "cpu": [
         "arm64"
       ],
@@ -1079,9 +1079,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
-      "integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.3.tgz",
+      "integrity": "sha512-tPfZiwF9rO0jW6Jh9ipi58N5ZLoSjdxXeSrAYypy4psA2Yl1dAMhM71KxVfmjZhJmxRjSnb29YlRXXhh3GqzYw==",
       "cpu": [
         "x64"
       ],
@@ -1095,9 +1095,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
-      "integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.3.tgz",
+      "integrity": "sha512-ERDyjOgYeKe0Vrlr1iLrqTByB026YLPzTytDTz1DRCYM+JI92Dw2dbpRHYmdqn6VBnQ9Bor6J8ZlNwdZdxjlSg==",
       "cpu": [
         "arm64"
       ],
@@ -1111,9 +1111,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
-      "integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.3.tgz",
+      "integrity": "sha512-nXesBZ2Ad1qL+Rm3crN7NmEVJ5uvfLFPLJev3x1j3feCQXfAhoYrojC681RhpdOph8NsvKBBwpYZHR7W0ifTTA==",
       "cpu": [
         "x64"
       ],
@@ -1127,9 +1127,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
-      "integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.3.tgz",
+      "integrity": "sha512-zr48Cg/8zkzZCzDHNxXO/89bf9e+r4HtzNUPoz4GmgAkF1gFAFmfgOdCbR8zMbzFDGb1FqBBhdXUpcTQRYS1cQ==",
       "cpu": [
         "arm"
       ],
@@ -1143,9 +1143,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
-      "integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.3.tgz",
+      "integrity": "sha512-qXvYKmXj8GcJgWq3aGvxL/JG1ZM3UR272SdPU4QSTzD0eymrM7leiZH77pvY3UetCy0k1xuXZ+VPvoJNdtrsWQ==",
       "cpu": [
         "arm64"
       ],
@@ -1159,9 +1159,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
-      "integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.3.tgz",
+      "integrity": "sha512-7XlCKCA0nWcbvYpusARWkFjRQNWNGlt45S+Q18UeS///K6Aw8bB2FKYe9mhVWy/XLShvCweOLZPrnMswIaDXQA==",
       "cpu": [
         "ia32"
       ],
@@ -1175,9 +1175,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
-      "integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.3.tgz",
+      "integrity": "sha512-qGTgjweER5xqweiWtUIDl9OKz338EQqCwbS9c2Bh5jgEH19xQ1yhgGPNesugmDFq+UUSDtWgZ264st26b3de8A==",
       "cpu": [
         "loong64"
       ],
@@ -1191,9 +1191,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
-      "integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.3.tgz",
+      "integrity": "sha512-gy1bFskwEyxVMFRNYSvBauDIWNggD6pyxUksc0MV9UOBD138dKTzr8XnM2R4mBsHwVzeuIH8X5JhmNs2Pzrx+A==",
       "cpu": [
         "mips64el"
       ],
@@ -1207,9 +1207,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
-      "integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.3.tgz",
+      "integrity": "sha512-UrYLFu62x1MmmIe85rpR3qou92wB9lEXluwMB/STDzPF9k8mi/9UvNsG07Tt9AqwPQXluMQ6bZbTzYt01+Ue5g==",
       "cpu": [
         "ppc64"
       ],
@@ -1223,9 +1223,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
-      "integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.3.tgz",
+      "integrity": "sha512-9E73TfyMCbE+1AwFOg3glnzZ5fBAFK4aawssvuMgCRqCYzE0ylVxxzjEfut8xjmKkR320BEoMui4o/t9KA96gA==",
       "cpu": [
         "riscv64"
       ],
@@ -1239,9 +1239,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
-      "integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.3.tgz",
+      "integrity": "sha512-LlmsbuBdm1/D66TJ3HW6URY8wO6IlYHf+ChOUz8SUAjVTuaisfuwCOAgcxo3Zsu3BZGxmI7yt//yGOxV+lHcEA==",
       "cpu": [
         "s390x"
       ],
@@ -1255,9 +1255,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
-      "integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.3.tgz",
+      "integrity": "sha512-ogV0+GwEmvwg/8ZbsyfkYGaLACBQWDvO0Kkh8LKBGKj9Ru8VM39zssrnu9Sxn1wbapA2qNS6BiLdwJZGouyCwQ==",
       "cpu": [
         "x64"
       ],
@@ -1271,9 +1271,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
-      "integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.3.tgz",
+      "integrity": "sha512-o1jLNe4uzQv2DKXMlmEzf66Wd8MoIhLNO2nlQBHLtWyh2MitDG7sMpfCO3NTcoTMuqHjfufgUQDFRI5C+xsXQw==",
       "cpu": [
         "x64"
       ],
@@ -1287,9 +1287,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
-      "integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.3.tgz",
+      "integrity": "sha512-AZJCnr5CZgZOdhouLcfRdnk9Zv6HbaBxjcyhq0StNcvAdVZJSKIdOiPB9az2zc06ywl0ePYJz60CjdKsQacp5Q==",
       "cpu": [
         "x64"
       ],
@@ -1303,9 +1303,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
-      "integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.3.tgz",
+      "integrity": "sha512-Acsujgeqg9InR4glTRvLKGZ+1HMtDm94ehTIHKhJjFpgVzZG9/pIcWW/HA/DoMfEyXmANLDuDZ2sNrWcjq1lxw==",
       "cpu": [
         "x64"
       ],
@@ -1319,9 +1319,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
-      "integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.3.tgz",
+      "integrity": "sha512-FSrAfjVVy7TifFgYgliiJOyYynhQmqgPj15pzLyJk8BUsnlWNwP/IAy6GAiB1LqtoivowRgidZsfpoYLZH586A==",
       "cpu": [
         "arm64"
       ],
@@ -1335,9 +1335,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
-      "integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.3.tgz",
+      "integrity": "sha512-xTScXYi12xLOWZ/sc5RBmMN99BcXp/eEf7scUC0oeiRoiT5Vvo9AycuqCp+xdpDyAU+LkrCqEpUS9fCSZF8J3Q==",
       "cpu": [
         "ia32"
       ],
@@ -1351,9 +1351,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
-      "integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.3.tgz",
+      "integrity": "sha512-FbUN+0ZRXsypPyWE2IwIkVjDkDnJoMJARWOcFZn4KPPli+QnKqF0z1anvfaYe3ev5HFCpRDLLBDHyOALLppWHw==",
       "cpu": [
         "x64"
       ],
@@ -4733,9 +4733,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.17.tgz",
-      "integrity": "sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.3.tgz",
+      "integrity": "sha512-UlJ1qUUA2jL2nNib1JTSkifQTcYTroFqRjwCFW4QYEKEsixXD5Tik9xML7zh2gTxkYTBKGHNH9y7txMwVyPbjw==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -4745,34 +4745,34 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.16.17",
-        "@esbuild/android-arm64": "0.16.17",
-        "@esbuild/android-x64": "0.16.17",
-        "@esbuild/darwin-arm64": "0.16.17",
-        "@esbuild/darwin-x64": "0.16.17",
-        "@esbuild/freebsd-arm64": "0.16.17",
-        "@esbuild/freebsd-x64": "0.16.17",
-        "@esbuild/linux-arm": "0.16.17",
-        "@esbuild/linux-arm64": "0.16.17",
-        "@esbuild/linux-ia32": "0.16.17",
-        "@esbuild/linux-loong64": "0.16.17",
-        "@esbuild/linux-mips64el": "0.16.17",
-        "@esbuild/linux-ppc64": "0.16.17",
-        "@esbuild/linux-riscv64": "0.16.17",
-        "@esbuild/linux-s390x": "0.16.17",
-        "@esbuild/linux-x64": "0.16.17",
-        "@esbuild/netbsd-x64": "0.16.17",
-        "@esbuild/openbsd-x64": "0.16.17",
-        "@esbuild/sunos-x64": "0.16.17",
-        "@esbuild/win32-arm64": "0.16.17",
-        "@esbuild/win32-ia32": "0.16.17",
-        "@esbuild/win32-x64": "0.16.17"
+        "@esbuild/android-arm": "0.19.3",
+        "@esbuild/android-arm64": "0.19.3",
+        "@esbuild/android-x64": "0.19.3",
+        "@esbuild/darwin-arm64": "0.19.3",
+        "@esbuild/darwin-x64": "0.19.3",
+        "@esbuild/freebsd-arm64": "0.19.3",
+        "@esbuild/freebsd-x64": "0.19.3",
+        "@esbuild/linux-arm": "0.19.3",
+        "@esbuild/linux-arm64": "0.19.3",
+        "@esbuild/linux-ia32": "0.19.3",
+        "@esbuild/linux-loong64": "0.19.3",
+        "@esbuild/linux-mips64el": "0.19.3",
+        "@esbuild/linux-ppc64": "0.19.3",
+        "@esbuild/linux-riscv64": "0.19.3",
+        "@esbuild/linux-s390x": "0.19.3",
+        "@esbuild/linux-x64": "0.19.3",
+        "@esbuild/netbsd-x64": "0.19.3",
+        "@esbuild/openbsd-x64": "0.19.3",
+        "@esbuild/sunos-x64": "0.19.3",
+        "@esbuild/win32-arm64": "0.19.3",
+        "@esbuild/win32-ia32": "0.19.3",
+        "@esbuild/win32-x64": "0.19.3"
       }
     },
     "node_modules/esbuild-node-externals": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esbuild-node-externals/-/esbuild-node-externals-1.6.0.tgz",
-      "integrity": "sha512-LmQnnDVMVTvMmPBpBDrCtub7CVW9aavBvF4ZjOLRNy/+ODoHz3kLjvDdMS/UKn1eJ5WrlAImiYsD3hF4YKyGkw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/esbuild-node-externals/-/esbuild-node-externals-1.9.0.tgz",
+      "integrity": "sha512-WV6Ogvl+AZEX3vWAM0UGxqb08l3M73EUeymizKGccUC0iWlF1CwdpkZVu200bSqONamjSV0v22vf4YBahJXs8g==",
       "dev": true,
       "dependencies": {
         "find-up": "^5.0.0",
@@ -4782,7 +4782,7 @@
         "node": ">=12"
       },
       "peerDependencies": {
-        "esbuild": "0.12 - 0.16"
+        "esbuild": "0.12 - 0.19"
       }
     },
     "node_modules/escalade": {
@@ -14758,156 +14758,156 @@
       }
     },
     "@esbuild/android-arm": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
-      "integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.3.tgz",
+      "integrity": "sha512-Lemgw4io4VZl9GHJmjiBGzQ7ONXRfRPHcUEerndjwiSkbxzrpq0Uggku5MxxrXdwJ+pTj1qyw4jwTu7hkPsgIA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/android-arm64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
-      "integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.19.3.tgz",
+      "integrity": "sha512-w+Akc0vv5leog550kjJV9Ru+MXMR2VuMrui3C61mnysim0gkFCPOUTAfzTP0qX+HpN9Syu3YA3p1hf3EPqObRw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/android-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
-      "integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.19.3.tgz",
+      "integrity": "sha512-FKQJKkK5MXcBHoNZMDNUAg1+WcZlV/cuXrWCoGF/TvdRiYS4znA0m5Il5idUwfxrE20bG/vU1Cr5e1AD6IEIjQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/darwin-arm64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.17.tgz",
-      "integrity": "sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.19.3.tgz",
+      "integrity": "sha512-kw7e3FXU+VsJSSSl2nMKvACYlwtvZB8RUIeVShIEY6PVnuZ3c9+L9lWB2nWeeKWNNYDdtL19foCQ0ZyUL7nqGw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/darwin-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
-      "integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.19.3.tgz",
+      "integrity": "sha512-tPfZiwF9rO0jW6Jh9ipi58N5ZLoSjdxXeSrAYypy4psA2Yl1dAMhM71KxVfmjZhJmxRjSnb29YlRXXhh3GqzYw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/freebsd-arm64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
-      "integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.3.tgz",
+      "integrity": "sha512-ERDyjOgYeKe0Vrlr1iLrqTByB026YLPzTytDTz1DRCYM+JI92Dw2dbpRHYmdqn6VBnQ9Bor6J8ZlNwdZdxjlSg==",
       "dev": true,
       "optional": true
     },
     "@esbuild/freebsd-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
-      "integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.19.3.tgz",
+      "integrity": "sha512-nXesBZ2Ad1qL+Rm3crN7NmEVJ5uvfLFPLJev3x1j3feCQXfAhoYrojC681RhpdOph8NsvKBBwpYZHR7W0ifTTA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-arm": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
-      "integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.19.3.tgz",
+      "integrity": "sha512-zr48Cg/8zkzZCzDHNxXO/89bf9e+r4HtzNUPoz4GmgAkF1gFAFmfgOdCbR8zMbzFDGb1FqBBhdXUpcTQRYS1cQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-arm64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
-      "integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.19.3.tgz",
+      "integrity": "sha512-qXvYKmXj8GcJgWq3aGvxL/JG1ZM3UR272SdPU4QSTzD0eymrM7leiZH77pvY3UetCy0k1xuXZ+VPvoJNdtrsWQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-ia32": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
-      "integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.19.3.tgz",
+      "integrity": "sha512-7XlCKCA0nWcbvYpusARWkFjRQNWNGlt45S+Q18UeS///K6Aw8bB2FKYe9mhVWy/XLShvCweOLZPrnMswIaDXQA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-loong64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
-      "integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.19.3.tgz",
+      "integrity": "sha512-qGTgjweER5xqweiWtUIDl9OKz338EQqCwbS9c2Bh5jgEH19xQ1yhgGPNesugmDFq+UUSDtWgZ264st26b3de8A==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-mips64el": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
-      "integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.19.3.tgz",
+      "integrity": "sha512-gy1bFskwEyxVMFRNYSvBauDIWNggD6pyxUksc0MV9UOBD138dKTzr8XnM2R4mBsHwVzeuIH8X5JhmNs2Pzrx+A==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-ppc64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
-      "integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.19.3.tgz",
+      "integrity": "sha512-UrYLFu62x1MmmIe85rpR3qou92wB9lEXluwMB/STDzPF9k8mi/9UvNsG07Tt9AqwPQXluMQ6bZbTzYt01+Ue5g==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-riscv64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
-      "integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.19.3.tgz",
+      "integrity": "sha512-9E73TfyMCbE+1AwFOg3glnzZ5fBAFK4aawssvuMgCRqCYzE0ylVxxzjEfut8xjmKkR320BEoMui4o/t9KA96gA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-s390x": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
-      "integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.19.3.tgz",
+      "integrity": "sha512-LlmsbuBdm1/D66TJ3HW6URY8wO6IlYHf+ChOUz8SUAjVTuaisfuwCOAgcxo3Zsu3BZGxmI7yt//yGOxV+lHcEA==",
       "dev": true,
       "optional": true
     },
     "@esbuild/linux-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
-      "integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.19.3.tgz",
+      "integrity": "sha512-ogV0+GwEmvwg/8ZbsyfkYGaLACBQWDvO0Kkh8LKBGKj9Ru8VM39zssrnu9Sxn1wbapA2qNS6BiLdwJZGouyCwQ==",
       "dev": true,
       "optional": true
     },
     "@esbuild/netbsd-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
-      "integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.3.tgz",
+      "integrity": "sha512-o1jLNe4uzQv2DKXMlmEzf66Wd8MoIhLNO2nlQBHLtWyh2MitDG7sMpfCO3NTcoTMuqHjfufgUQDFRI5C+xsXQw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/openbsd-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
-      "integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.19.3.tgz",
+      "integrity": "sha512-AZJCnr5CZgZOdhouLcfRdnk9Zv6HbaBxjcyhq0StNcvAdVZJSKIdOiPB9az2zc06ywl0ePYJz60CjdKsQacp5Q==",
       "dev": true,
       "optional": true
     },
     "@esbuild/sunos-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
-      "integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.19.3.tgz",
+      "integrity": "sha512-Acsujgeqg9InR4glTRvLKGZ+1HMtDm94ehTIHKhJjFpgVzZG9/pIcWW/HA/DoMfEyXmANLDuDZ2sNrWcjq1lxw==",
       "dev": true,
       "optional": true
     },
     "@esbuild/win32-arm64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
-      "integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.19.3.tgz",
+      "integrity": "sha512-FSrAfjVVy7TifFgYgliiJOyYynhQmqgPj15pzLyJk8BUsnlWNwP/IAy6GAiB1LqtoivowRgidZsfpoYLZH586A==",
       "dev": true,
       "optional": true
     },
     "@esbuild/win32-ia32": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
-      "integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.19.3.tgz",
+      "integrity": "sha512-xTScXYi12xLOWZ/sc5RBmMN99BcXp/eEf7scUC0oeiRoiT5Vvo9AycuqCp+xdpDyAU+LkrCqEpUS9fCSZF8J3Q==",
       "dev": true,
       "optional": true
     },
     "@esbuild/win32-x64": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
-      "integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.19.3.tgz",
+      "integrity": "sha512-FbUN+0ZRXsypPyWE2IwIkVjDkDnJoMJARWOcFZn4KPPli+QnKqF0z1anvfaYe3ev5HFCpRDLLBDHyOALLppWHw==",
       "dev": true,
       "optional": true
     },
@@ -17567,39 +17567,39 @@
       }
     },
     "esbuild": {
-      "version": "0.16.17",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.17.tgz",
-      "integrity": "sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==",
+      "version": "0.19.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.3.tgz",
+      "integrity": "sha512-UlJ1qUUA2jL2nNib1JTSkifQTcYTroFqRjwCFW4QYEKEsixXD5Tik9xML7zh2gTxkYTBKGHNH9y7txMwVyPbjw==",
       "dev": true,
       "requires": {
-        "@esbuild/android-arm": "0.16.17",
-        "@esbuild/android-arm64": "0.16.17",
-        "@esbuild/android-x64": "0.16.17",
-        "@esbuild/darwin-arm64": "0.16.17",
-        "@esbuild/darwin-x64": "0.16.17",
-        "@esbuild/freebsd-arm64": "0.16.17",
-        "@esbuild/freebsd-x64": "0.16.17",
-        "@esbuild/linux-arm": "0.16.17",
-        "@esbuild/linux-arm64": "0.16.17",
-        "@esbuild/linux-ia32": "0.16.17",
-        "@esbuild/linux-loong64": "0.16.17",
-        "@esbuild/linux-mips64el": "0.16.17",
-        "@esbuild/linux-ppc64": "0.16.17",
-        "@esbuild/linux-riscv64": "0.16.17",
-        "@esbuild/linux-s390x": "0.16.17",
-        "@esbuild/linux-x64": "0.16.17",
-        "@esbuild/netbsd-x64": "0.16.17",
-        "@esbuild/openbsd-x64": "0.16.17",
-        "@esbuild/sunos-x64": "0.16.17",
-        "@esbuild/win32-arm64": "0.16.17",
-        "@esbuild/win32-ia32": "0.16.17",
-        "@esbuild/win32-x64": "0.16.17"
+        "@esbuild/android-arm": "0.19.3",
+        "@esbuild/android-arm64": "0.19.3",
+        "@esbuild/android-x64": "0.19.3",
+        "@esbuild/darwin-arm64": "0.19.3",
+        "@esbuild/darwin-x64": "0.19.3",
+        "@esbuild/freebsd-arm64": "0.19.3",
+        "@esbuild/freebsd-x64": "0.19.3",
+        "@esbuild/linux-arm": "0.19.3",
+        "@esbuild/linux-arm64": "0.19.3",
+        "@esbuild/linux-ia32": "0.19.3",
+        "@esbuild/linux-loong64": "0.19.3",
+        "@esbuild/linux-mips64el": "0.19.3",
+        "@esbuild/linux-ppc64": "0.19.3",
+        "@esbuild/linux-riscv64": "0.19.3",
+        "@esbuild/linux-s390x": "0.19.3",
+        "@esbuild/linux-x64": "0.19.3",
+        "@esbuild/netbsd-x64": "0.19.3",
+        "@esbuild/openbsd-x64": "0.19.3",
+        "@esbuild/sunos-x64": "0.19.3",
+        "@esbuild/win32-arm64": "0.19.3",
+        "@esbuild/win32-ia32": "0.19.3",
+        "@esbuild/win32-x64": "0.19.3"
       }
     },
     "esbuild-node-externals": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esbuild-node-externals/-/esbuild-node-externals-1.6.0.tgz",
-      "integrity": "sha512-LmQnnDVMVTvMmPBpBDrCtub7CVW9aavBvF4ZjOLRNy/+ODoHz3kLjvDdMS/UKn1eJ5WrlAImiYsD3hF4YKyGkw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/esbuild-node-externals/-/esbuild-node-externals-1.9.0.tgz",
+      "integrity": "sha512-WV6Ogvl+AZEX3vWAM0UGxqb08l3M73EUeymizKGccUC0iWlF1CwdpkZVu200bSqONamjSV0v22vf4YBahJXs8g==",
       "dev": true,
       "requires": {
         "find-up": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -81,8 +81,8 @@
     "@types/semver": "^7.3.13",
     "@types/serverless": "^3.12.14",
     "all-contributors-cli": "^6.24.0",
-    "esbuild": "^0.16.17",
-    "esbuild-node-externals": "^1.6.0",
+    "esbuild": "^0.19.3",
+    "esbuild-node-externals": "^1.9.0",
     "eslint": "^8.30.0",
     "extract-zip": "^2.0.1",
     "husky": "^8.0.2",
@@ -96,7 +96,7 @@
     "typescript": "^4.9.4"
   },
   "peerDependencies": {
-    "esbuild": ">=0.8 <0.18",
+    "esbuild": ">=0.8 <0.20",
     "esbuild-node-externals": "^1.0.0"
   },
   "peerDependenciesMeta": {

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import type { BuildOptions } from 'esbuild';
+import type { BuildOptions, BuildResult } from 'esbuild';
 import fs from 'fs-extra';
 import pMap from 'p-map';
 import path from 'path';
@@ -102,7 +102,12 @@ export async function bundle(this: EsbuildServerlessPlugin): Promise<void> {
 
     const pkg = await import('esbuild');
     const context: BuildContext = await pkg.context(options);
-    const result = await context.rebuild();
+    let result!: BuildResult;
+    if (context) {
+      result = await context.rebuild();
+    } else {
+      result = await pkg.build(options);
+    }
 
     if (config.metafile) {
       fs.writeFileSync(

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,5 +1,4 @@
 import assert from 'assert';
-import { build } from 'esbuild';
 import type { BuildOptions } from 'esbuild';
 import fs from 'fs-extra';
 import pMap from 'p-map';
@@ -101,8 +100,9 @@ export async function bundle(this: EsbuildServerlessPlugin): Promise<void> {
       outdir: path.join(buildDirPath, path.dirname(entry)),
     };
 
-    let context!: BuildContext;
-    const result = await build(options);
+    const pkg = await import('esbuild');
+    const context: BuildContext = await pkg.context(options);
+    const result = await context.rebuild();
 
     if (config.metafile) {
       fs.writeFileSync(

--- a/src/index.ts
+++ b/src/index.ts
@@ -360,6 +360,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
     chokidar.watch(allPatterns, options).on('all', (eventName, srcPath) =>
       this.bundle(true)
         .then(() => this.updateFile(eventName, srcPath))
+        .then(() => this.notifyServerlessOffline())
         .then(() => this.log.verbose('Watching files for changes...'))
         .catch(() => this.log.error('Bundle error, waiting for a file change to reload...'))
     );
@@ -398,6 +399,10 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
         ...(patterns.length && { patterns }),
       };
     }
+  }
+
+  notifyServerlessOffline() {
+    this.serverless.pluginManager.spawn('offline:functionsUpdated');
   }
 
   async updateFile(op: string, filename: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,7 +159,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       },
       'after:package:createDeploymentArtifacts': async () => {
         this.log.verbose('after:package:createDeploymentArtifacts');
-        await this.disposeContexes();
+        await this.disposeContexts();
         await this.cleanup();
       },
       'before:deploy:function:packageFunction': async () => {
@@ -171,7 +171,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       },
       'after:deploy:function:packageFunction': async () => {
         this.log.verbose('after:deploy:function:packageFunction');
-        await this.disposeContexes();
+        await this.disposeContexts();
         await this.cleanup();
       },
       'before:invoke:local:invoke': async () => {
@@ -182,7 +182,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
         await this.preLocal();
       },
       'after:invoke:local:invoke': async () => {
-        await this.disposeContexes();
+        await this.disposeContexts();
       },
     };
   }
@@ -515,7 +515,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
     service.package.artifact = path.join(SERVERLESS_FOLDER, path.basename(service.package.artifact));
   }
 
-  async disposeContexes(): Promise<void> {
+  async disposeContexts(): Promise<void> {
     for (const { context } of Object.values(this.buildCache)) {
       if (context) {
         await context.dispose();

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,6 +159,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       },
       'after:package:createDeploymentArtifacts': async () => {
         this.log.verbose('after:package:createDeploymentArtifacts');
+        await this.disposeContexes();
         await this.cleanup();
       },
       'before:deploy:function:packageFunction': async () => {
@@ -170,6 +171,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       },
       'after:deploy:function:packageFunction': async () => {
         this.log.verbose('after:deploy:function:packageFunction');
+        await this.disposeContexes();
         await this.cleanup();
       },
       'before:invoke:local:invoke': async () => {
@@ -178,6 +180,9 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
         await this.packExternalModules();
         await this.copyExtras();
         await this.preLocal();
+      },
+      'after:invoke:local:invoke': async () => {
+        await this.disposeContexes();
       },
     };
   }
@@ -508,6 +513,14 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
     }
 
     service.package.artifact = path.join(SERVERLESS_FOLDER, path.basename(service.package.artifact));
+  }
+
+  async disposeContexes(): Promise<void> {
+    for (const { context } of Object.values(this.buildCache)) {
+      if (context) {
+        await context.dispose();
+      }
+    }
   }
 
   async cleanup(): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,7 +134,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       },
       'before:offline:start': async () => {
         this.log.verbose('before:offline:start');
-        await this.bundle(true);
+        await this.bundle();
         await this.packExternalModules();
         await this.copyExtras();
         await this.preOffline();
@@ -142,7 +142,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
       },
       'before:offline:start:init': async () => {
         this.log.verbose('before:offline:start:init');
-        await this.bundle(true);
+        await this.bundle();
         await this.packExternalModules();
         await this.copyExtras();
         await this.preOffline();
@@ -358,7 +358,7 @@ class EsbuildServerlessPlugin implements ServerlessPlugin {
     };
 
     chokidar.watch(allPatterns, options).on('all', (eventName, srcPath) =>
-      this.bundle(true)
+      this.bundle()
         .then(() => this.updateFile(eventName, srcPath))
         .then(() => this.notifyServerlessOffline())
         .then(() => this.log.verbose('Watching files for changes...'))

--- a/src/tests/bundle.test.ts
+++ b/src/tests/bundle.test.ts
@@ -11,8 +11,6 @@ jest.mock('esbuild');
 jest.mock('p-map');
 
 const getBuild = async () => {
-  const pkg: any = await import('esbuild');
-  if (pkg.context) return pkg.context;
   return build;
 };
 
@@ -200,7 +198,6 @@ it('should filter out non esbuild options', async () => {
     bundle: true,
     entryPoints: ['file1.ts'],
     external: ['aws-sdk'],
-    incremental: false,
     outdir: '/workdir/.esbuild',
     platform: 'node',
     plugins: [],
@@ -208,8 +205,6 @@ it('should filter out non esbuild options', async () => {
   };
 
   const proxy = await getBuild();
-  const pkg: any = await import('esbuild');
-  if (pkg.context) delete config.incremental;
 
   expect(proxy).toBeCalledWith(config);
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,6 @@ export interface Configuration extends EsbuildOptions {
   installExtraArgs: string[];
   plugins?: string | Plugin[];
   keepOutputDirectory?: boolean;
-  disableIncremental?: boolean;
   outputWorkFolder?: string;
   outputBuildFolder?: string;
   outputFileExtension: '.js' | '.cjs' | '.mjs';


### PR DESCRIPTION
According to documentation of the changes in esbuild 0.17, calling rebuild on the same build params is “safe” in the sense that it would merge it into an existing build rather then spawn a new one.

Furthermore, the contexes of these rebuilds are now needed to be disposed of. That was the original issue that made me use build over the rebuild - in the initial import of esbuild 19, running serverless invoke and serverless package would never finish. Using build seemingly solved this, but it ended up causing the issue spawning too many builds described above.

I added a step on finishing invoking, deploying and packaging to make sure to dispose of the contexes.